### PR TITLE
Better client tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [~1.17, ^1]
+        go-version: [~1.17]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: setup loopback macos
+        run: sudo ifconfig lo0 alias 127.0.0.2 up
+        if: contains(matrix.os, 'macos')
+
       - name: Test
         run: go test ./...

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,7 +7,6 @@ import (
 
 	cfs "github.com/charmbracelet/charm/fs"
 	"github.com/rubiojr/tavern/internal/testutil"
-	ts "github.com/rubiojr/tavern/server"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,12 +25,7 @@ func TestPublish(t *testing.T) {
 		assert.FailNow(t, "error starting charm client")
 	}
 
-	tav := ts.NewServerWithConfig(&ts.Config{
-		Addr:           "127.0.0.2:8000",
-		UploadsPath:    tdir + "/uploads",
-		CharmServerURL: "http://127.0.0.2:35354",
-	})
-	go tav.Serve(ctx)
+	testutil.TavernServer(ctx, tdir)
 
 	// Create a new client.
 	tcc := DefaultConfig()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,6 +17,14 @@ func TestPublish(t *testing.T) {
 	defer cancel()
 
 	err := testutil.StartCharmServer(ctx, tdir)
+	if err != nil {
+		assert.FailNow(t, "error starting charm server")
+	}
+
+	cc, err := testutil.CharmClient()
+	if err != nil {
+		assert.FailNow(t, "error starting charm client")
+	}
 
 	tav := ts.NewServerWithConfig(&ts.Config{
 		Addr:           "127.0.0.2:8000",
@@ -32,11 +40,6 @@ func TestPublish(t *testing.T) {
 	c, err := NewClientWithConfig(tcc)
 	if err != nil {
 		assert.FailNow(t, "error creating tavern client", err)
-	}
-
-	cc, err := testutil.CharmClient()
-	if err != nil {
-		assert.FailNow(t, "error starting charm client")
 	}
 
 	charmfs, err := cfs.NewFSWithClient(cc)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -31,7 +31,7 @@ func TestPublish(t *testing.T) {
 	tcc.ServerURL = testutil.ServerURL
 	c, err := NewClientWithConfig(tcc)
 	if err != nil {
-		assert.FailNow(t, "error creating tavern client")
+		assert.FailNow(t, "error creating tavern client", err)
 	}
 
 	cc, err := testutil.CharmClient()


### PR DESCRIPTION
* Test only one Go version
* macOS CI fixes
* Refactor tavern server bootstrap code into a function to be reused